### PR TITLE
When no @Typed annotations is specified default to an Interface

### DIFF
--- a/org.eclipse.sisu.inject/src/org/eclipse/sisu/space/QualifiedTypeBinder.java
+++ b/org.eclipse.sisu.inject/src/org/eclipse/sisu/space/QualifiedTypeBinder.java
@@ -261,7 +261,7 @@ public final class QualifiedTypeBinder
         }
 
         final Named bindingName = getBindingName( qualifiedType );
-        final Class<?>[] types = getBindingTypes( qualifiedType );
+        final Class<?>[] types = getBindingQualifierType( qualifiedType );
 
         if ( null != types )
         {
@@ -411,6 +411,21 @@ public final class QualifiedTypeBinder
             }
         }
         return null;
+    }
+
+    private static Class<?>[] getBindingQualifierType( final Class<?> clazz )
+    {
+        Class<?>[] types = getBindingTypes(clazz);
+
+        if (types == null) {
+            if (clazz != null && clazz != Object.class && clazz.getInterfaces().length > 0) {
+                return clazz.getInterfaces();
+            } else {
+                return null;
+            }
+        } else {
+            return types;
+        }
     }
 
     private static boolean isSingleton( final Class<?> type )


### PR DESCRIPTION
When no @Typed annotations is specified make binding to a classes interface preferred. If none specified fall back to binding to itself. 

We found the default behaviour counter-intuitive 

    @Named
    class DefaultMyClass implements MyType {}

The above class is bound to `DefaultMyClass` not to `MyType`. Our expectation was that we would get a binding to `MyType` not  `DefaultMyClass` so this fails:

    @Named
    class MyService {
        @Inject
        MyType mytype;
    }

The existing behaviour for class hierachy still applies in that you are required to use `@Typed` to specify interfaces that are not directly implemented.