### PR TITLE
Added javadoc to annotation define what the priority order is.

### DIFF
--- a/org.eclipse.sisu.inject/src/org/eclipse/sisu/Priority.java
+++ b/org.eclipse.sisu.inject/src/org/eclipse/sisu/Priority.java
@@ -17,9 +17,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the priority ordering of a bean:<br>
+ * Defines the priority ordering of a bean. Higher values have higher priority. When no {@link Priority} is not defined the default bean (refer to
+ * com.eclipse.sisu.space javadoc) will have priority over any other beans:<br>
  * <br>
- * 
+ *
+ *
  * <pre>
  * &#064;Named
  * &#064;Priority( 999 )


### PR DESCRIPTION
I had to look at the tests to work out if 1 or 100 was higher priority

Also I couldn't work out how to create a link to a package so I didn't link to the docs at `com.eclipse.sisu.space` that talk about default beans.